### PR TITLE
Switch to Method::Signatures::Simple

### DIFF
--- a/lib/Git/CPAN/Patch.pm
+++ b/lib/Git/CPAN/Patch.pm
@@ -8,7 +8,7 @@ use MooseX::App 1.21;
 use MooseX::SemiAffordanceAccessor;
 
 use MetaCPAN::API;
-use Method::Signatures 20121201;
+use Method::Signatures::Simple 1.07;
 
 app_base 'git-cpan';
 app_namespace 'Git::CPAN::Patch::Command';

--- a/lib/Git/CPAN/Patch/Command/Clone.pm
+++ b/lib/Git/CPAN/Patch/Command/Clone.pm
@@ -8,7 +8,7 @@ use warnings;
 
 use autodie;
 use Path::Class;
-use Method::Signatures;
+use Method::Signatures::Simple;
 
 use MooseX::App::Command;
 extends 'Git::CPAN::Patch::Command::Import';
@@ -36,7 +36,7 @@ before import_release => method($release) {
     $first = 0;
 };
 
-after import_release => method(...) {
+after import_release => method {
     $self->git_run( 'reset', '--hard', $self->last_commit );    
 };
 

--- a/lib/Git/CPAN/Patch/Command/FormatPatch.pm
+++ b/lib/Git/CPAN/Patch/Command/FormatPatch.pm
@@ -6,7 +6,7 @@ use 5.10.0;
 use strict;
 use warnings;
 
-use Method::Signatures;
+use Method::Signatures::Simple;
 
 use MooseX::App::Command;
 

--- a/lib/Git/CPAN/Patch/Command/Import.pm
+++ b/lib/Git/CPAN/Patch/Command/Import.pm
@@ -7,7 +7,7 @@ use strict;
 use warnings;
 
 use File::Temp qw/ tempdir /;
-use Method::Signatures;
+use Method::Signatures::Simple;
 use Git::Repository;
 use Git::CPAN::Patch::Import;
 use File::chdir;

--- a/lib/Git/CPAN/Patch/Command/SendEmail.pm
+++ b/lib/Git/CPAN/Patch/Command/SendEmail.pm
@@ -6,7 +6,7 @@ use 5.10.0;
 use strict;
 use warnings;
 
-use Method::Signatures;
+use Method::Signatures::Simple;
 
 use MooseX::App::Command;
 

--- a/lib/Git/CPAN/Patch/Command/SendPatch.pm
+++ b/lib/Git/CPAN/Patch/Command/SendPatch.pm
@@ -6,7 +6,7 @@ use 5.10.0;
 use strict;
 use warnings;
 
-use Method::Signatures;
+use Method::Signatures::Simple;
 
 use MooseX::App::Command;
 

--- a/lib/Git/CPAN/Patch/Command/Sources.pm
+++ b/lib/Git/CPAN/Patch/Command/Sources.pm
@@ -6,7 +6,7 @@ use 5.10.0;
 use strict;
 use warnings;
 
-use Method::Signatures;
+use Method::Signatures::Simple;
 use List::Pairwise qw/ mapp /;
 
 use MooseX::App::Command;

--- a/lib/Git/CPAN/Patch/Command/Squash.pm
+++ b/lib/Git/CPAN/Patch/Command/Squash.pm
@@ -6,7 +6,7 @@ use 5.10.0;
 use strict;
 use warnings;
 
-use Method::Signatures;
+use Method::Signatures::Simple;
 use Git::Repository;
 
 use MooseX::App::Command;

--- a/lib/Git/CPAN/Patch/Command/Update.pm
+++ b/lib/Git/CPAN/Patch/Command/Update.pm
@@ -6,7 +6,7 @@ use 5.10.0;
 use strict;
 use warnings;
 
-use Method::Signatures;
+use Method::Signatures::Simple;
 use Git::Repository;
 
 use MooseX::App::Command;

--- a/lib/Git/CPAN/Patch/Command/Which.pm
+++ b/lib/Git/CPAN/Patch/Command/Which.pm
@@ -6,7 +6,7 @@ use 5.10.0;
 use strict;
 use warnings;
 
-use Method::Signatures;
+use Method::Signatures::Simple;
 use MooseX::App::Command;
 
 with 'Git::CPAN::Patch::Role::Git'; 

--- a/lib/Git/CPAN/Patch/Release.pm
+++ b/lib/Git/CPAN/Patch/Release.pm
@@ -3,7 +3,7 @@ package Git::CPAN::Patch::Release;
 use strict;
 use warnings;
 
-use Method::Signatures;
+use Method::Signatures::Simple;
 use File::chdir;
 use File::Temp qw/ tempdir /;
 use version;

--- a/lib/Git/CPAN/Patch/Role/Git.pm
+++ b/lib/Git/CPAN/Patch/Role/Git.pm
@@ -4,7 +4,7 @@ package Git::CPAN::Patch::Role::Git;
 use strict;
 use warnings;
 
-use Method::Signatures;
+use Method::Signatures::Simple;
 use version;
 
 use Moose::Role;

--- a/lib/Git/CPAN/Patch/Role/Patch.pm
+++ b/lib/Git/CPAN/Patch/Role/Patch.pm
@@ -5,7 +5,7 @@ use 5.10.0;
 use strict;
 use warnings;
 
-use Method::Signatures;
+use Method::Signatures::Simple;
 
 use Moose::Role;
 


### PR DESCRIPTION
Method::Signatures depends on Data::Alias, which has been broken since
5.17.2 and shows no sign of being fixed by 5.18.
