### PR TITLE
Make send-email error less confusing

### DIFF
--- a/lib/Git/CPAN/Patch/Role/Git.pm
+++ b/lib/Git/CPAN/Patch/Role/Git.pm
@@ -44,7 +44,7 @@ method last_imported_version {
     my $last = join "\n", $self->git_run( log => '--pretty=format:%b', '-n', 1, $last_commit );
 
     $last =~ /git-cpan-module:\ (.*?) \s+ git-cpan-version: \s+ (\S+)/sx
-        or die "Couldn't parse message:\n$last\n";
+        or die "Couldn't parse message (not cloned via git cpan import?):\n$last\n";
 
     return version->parse($2);
 }
@@ -55,7 +55,7 @@ method tracked_distribution {
     my $last = join "\n", $self->git_run( log => '--pretty=format:%b', '-n', 1, $last_commit );
 
     $last =~ /git-cpan-module:\s+ (.*?) \s+ git-cpan-version: \s+ (\S+)/sx
-        or die "Couldn't parse message:\n$last\n";
+        or die "Couldn't parse message (not cloned via git cpan import?):\n$last\n";
 
     return $1;
 }

--- a/lib/Git/CPAN/Patch/Role/Patch.pm
+++ b/lib/Git/CPAN/Patch/Role/Patch.pm
@@ -44,7 +44,7 @@ has module_name => (
         my $last = join "\n", $self->git->run( log => '--pretty=format:%b', '-n', 1, $last_commit );
 
         $last =~ /git-cpan-module: \s+ (.*?) \s+ git-cpan-version: \s+ (.*?) \s*$/sx
-            or die "Couldn't parse message:\n$last\n";
+            or die "Couldn't parse message (not cloned via git cpan import?):\n$last\n";
 
         $self->git->run('config', 'cpan.module-name', $1);
 


### PR DESCRIPTION
Ok so this is a really basic fix for a more serious problem.  Basically, I did:

```
git cpan clone Git-CPAN-Patch
```

Then I fixed a problem, and wanted to send a patch for a fix via RT (to test my
fix:)

```
git cpan send-patch
```

And it errored saying:

```
Couldn't parse message:

 [BUG FIXES]
 - Tests were failing because of space-sensitivity. (lharey, GH#21)

 [ENHANCEMENTS]
 - Move to MetaCPAN::Client. (GH#19)

 [STATISTICS]
 - code churn: 14 files changed, 233 insertions(+), 210 deletions(-)

```

Which is pretty confusing!  So I made the error explain why the message needs to
be parsed in the first place.

A much better fix would be to have `git cpan clone` add some metadata to the _.git/config_
so that

1. No parsing needs to be done
2. `git cpan send-patch` works for those who use both RT and Github (I expect
   such bizarros must exist somewhere!)

I may get around to fixing that some time later.

