### PR TITLE
Allow git to prompt user when calling send-email

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,9 @@ Revision history for Git::CPAN::Patch
   [ API CHANGES ]
 
   [ BUG FIXES ]
+    - Allow git to prompt user when calling sendemail
+      (Arthur Axel fREW Schmidt)
+
 
   [ DOCUMENTATION ]
 

--- a/lib/Git/CPAN/Patch/Role/Patch.pm
+++ b/lib/Git/CPAN/Patch/Role/Patch.pm
@@ -55,8 +55,7 @@ has module_name => (
 method send_emails(@patches) {
     my $to = 'bug-' . $self->module_name . '@rt.cpan.org';
 
-    say for $self->git_run("send-email", '--no-chain-reply-to', "--to", $to,
-    @patches );
+    system 'git', "send-email", '--no-chain-reply-to', "--to", $to, @patches;
 }
 
 1;


### PR DESCRIPTION
When I run `git send-email` git prompts me for some extra information, or maybe
it's just a confirmation.  This manifests itself as eternal blocking when it
comes to Git::CPAN::Patch, I think because of the way System::Command works.

I haven't been able to test this patch but I'm 90% sure it works.  If I get
a chance I'll do some more work to test it.


