### PR TITLE
Store module name in configuration

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,297 +1,304 @@
 Revision history for Git::CPAN::Patch
 
 {{$NEXT}}
- [API CHANGES]
+  [ API CHANGES ]
 
- [BUG FIXES]
+  [ BUG FIXES ]
 
- [DOCUMENTATION]
+  [ DOCUMENTATION ]
 
- [ENHANCEMENTS]
- - Be a little more clever about finding out if the META repo is git-based.
+  [ ENHANCEMENTS ]
 
- [NEW FEATURES]
+  [ NEW FEATURES ]
 
- [STATISTICS]
+  [ STATISTICS ]
+
+2.1.0 2015-06-01
+  [ ENHANCEMENTS ]
+    - Be a little more clever about finding out if the META repo is
+      git-based.
+
+  [ STATISTICS ]
+    - code churn: 3 files changed, 22 insertions(+), 4 deletions(-)
 
 2.0.4 2015-04-19
- [BUG FIXES]
- - Tests were failing because of space-sensitivity. (lharey, GH#21)
+  [ BUG FIXES ]
+    - Tests were failing because of space-sensitivity. (lharey, GH#21)
 
- [ENHANCEMENTS]
- - Move to MetaCPAN::Client. (GH#19)
+  [ ENHANCEMENTS ]
+    - Move to MetaCPAN::Client. (GH#19)
 
- [STATISTICS]
- - code churn: 14 files changed, 233 insertions(+), 210 deletions(-)
+  [ STATISTICS ]
+    - code churn: 14 files changed, 233 insertions(+), 210 deletions(-)
 
 2.0.3 2014-03-17
- [BUG FIXES]
- - Deal with any archives and other fixes. (RT#92928, reported by Alexandr
-   Ciornii)
+  [ BUG FIXES ]
+    - Deal with any archives and other fixes. (RT#92928, reported by
+      Alexandr Ciornii)
 
- [STATISTICS]
- - code churn: 7 files changed, 79 insertions(+), 26 deletions(-)
+  [ STATISTICS ]
+    - code churn: 7 files changed, 79 insertions(+), 26 deletions(-)
 
 2.0.2 2014-03-03
- [BUG FIXES]
- - Author and date of release take precedence over the GIT_* env variables.
-   (RT#93481, reported by Slaven Rezic)
+  [ BUG FIXES ]
+    - Author and date of release take precedence over the GIT_* env
+      variables. (RT#93481, reported by Slaven Rezic)
 
- [DOCUMENTATION]
- - Remove mention of option '--backpan' for import. (RT#93482, raised by
-   Slaven Rezic)
+  [ DOCUMENTATION ]
+    - Remove mention of option '--backpan' for import. (RT#93482, raised by
+      Slaven Rezic)
 
- [STATISTICS]
- - code churn: 4 files changed, 18 insertions(+), 42 deletions(-)
+  [ STATISTICS ]
+    - code churn: 4 files changed, 18 insertions(+), 42 deletions(-)
 
 2.0.1 2014-02-15
- [BUG FIXES]
- - Added dependency to Git::Repository::Plugin::AUTOLOAD.
- - Re-introduced Pod::Weaver (spotted by Neil Bowers).
+  [ BUG FIXES ]
+    - Added dependency to Git::Repository::Plugin::AUTOLOAD.
+    - Re-introduced Pod::Weaver (spotted by Neil Bowers).
 
- [STATISTICS]
- - code churn: 3 files changed, 14 insertions(+), 4 deletions(-)
+  [ STATISTICS ]
+    - code churn: 3 files changed, 14 insertions(+), 4 deletions(-)
 
 2.0.0 2014-02-12
- [API CHANGES]
- - Will now clone of the official git repository, if there is one.
+  [ API CHANGES ]
+    - Will now clone of the official git repository, if there is one.
 
- [STATISTICS]
- - code churn: 13 files changed, 385 insertions(+), 64 deletions(-)
+  [ STATISTICS ]
+    - code churn: 13 files changed, 385 insertions(+), 64 deletions(-)
 
 1.3.1 2013-07-27
- [BUG FIXES]
- - Bump minimal Perl requirements to 5.10.1 (for smartmatches).
+  [ BUG FIXES ]
+    - Bump minimal Perl requirements to 5.10.1 (for smartmatches).
 
- [STATISTICS]
- - code churn: 2 files changed, 10 insertions(+), 2 deletions(-)
+  [ STATISTICS ]
+    - code churn: 2 files changed, 10 insertions(+), 2 deletions(-)
 
 1.3.0 2013-07-18
- [ENHANCEMENTS]
- - Silence smart-match warnings for 5.18+
+  [ ENHANCEMENTS ]
+    - Silence smart-match warnings for 5.18+
 
- [STATISTICS]
- - code churn: 2 files changed, 25 insertions(+), 16 deletions(-)
+  [ STATISTICS ]
+    - code churn: 2 files changed, 25 insertions(+), 16 deletions(-)
 
 1.2.1 2013-07-15
- [BUG FIXES]
- - Was using 'return $foo or die' instead of 'return $foo || die'.
+  [ BUG FIXES ]
+    - Was using 'return $foo or die' instead of 'return $foo || die'.
 
- [STATISTICS]
- - code churn: 2 files changed, 11 insertions(+), 4 deletions(-)
+  [ STATISTICS ]
+    - code churn: 2 files changed, 11 insertions(+), 4 deletions(-)
 
 1.2.0 2013-04-21
- [ENHANCEMENTS]
- - Move to Method:::Signature::Simple as M::S doesn't work with 5.17.11. 
-   (GH#14, ilmari)
+  [ ENHANCEMENTS ]
+    - Move to Method:::Signature::Simple as M::S doesn't work with 5.17.11.
+      (GH#14, ilmari)
 
- [STATISTICS]
- - code churn: 14 files changed, 32 insertions(+), 16 deletions(-)
+  [ STATISTICS ]
+    - code churn: 14 files changed, 32 insertions(+), 16 deletions(-)
 
 1.1.2 2013-04-14
- [BUG FIXES]
- - bump dependency for MooseX::App to solve boolean argument problem.
+  [ BUG FIXES ]
+    - bump dependency for MooseX::App to solve boolean argument problem.
 
- [STATISTICS]
- - code churn: 2 files changed, 9 insertions(+), 10 deletions(-)
+  [ STATISTICS ]
+    - code churn: 2 files changed, 9 insertions(+), 10 deletions(-)
 
 1.1.1 2013-04-01
- [BUG FIXES]
- - changes in latest MooseX::App broke Git::CPAN::Patch  (RT#84349,
-   reported by Peter Valdemar MÃ¸rch)
+  [ BUG FIXES ]
+    - changes in latest MooseX::App broke Git::CPAN::Patch  (RT#84349,
+      reported by Peter Valdemar Mørch)
 
- [STATISTICS]
- - code churn: 8 files changed, 47 insertions(+), 18 deletions(-)
+  [ STATISTICS ]
+    - code churn: 8 files changed, 47 insertions(+), 18 deletions(-)
 
 1.1.0 2013-01-19
- [ENHANCEMENTS]
- - Simplify code after MooseX::App improvements (maros rocks)
+  [ ENHANCEMENTS ]
+    - Simplify code after MooseX::App improvements (maros rocks)
 
- [STATISTICS]
- - code churn: 2 files changed, 19 insertions(+), 75 deletions(-)
+  [ STATISTICS ]
+    - code churn: 2 files changed, 19 insertions(+), 75 deletions(-)
 
 1.0.3 2013-01-08
- [BUG FIXES]
- - Specify Method::Signature minimal version.
+  [ BUG FIXES ]
+    - Specify Method::Signature minimal version.
 
- [STATISTICS]
- - code churn: 2 files changed, 14 insertions(+), 7 deletions(-)
+  [ STATISTICS ]
+    - code churn: 2 files changed, 14 insertions(+), 7 deletions(-)
 
 1.0.2 2013-01-03
- [BUG FIXES]
- - Removed s///r use.
+  [ BUG FIXES ]
+    - Removed s///r use.
 
- [STATISTICS]
- - code churn: 2 files changed, 17 insertions(+), 7 deletions(-)
+  [ STATISTICS ]
+    - code churn: 2 files changed, 17 insertions(+), 7 deletions(-)
 
 1.0.1 2013-01-01
- [BUG FIXES]
- - Hide the MooseX::App monkeypatching from the cpan indexer.
+  [ BUG FIXES ]
+    - Hide the MooseX::App monkeypatching from the cpan indexer.
 
- [DOCUMENTATION]
- - Change 'git cpan' for the new 'git-cpan'.
+  [ DOCUMENTATION ]
+    - Change 'git cpan' for the new 'git-cpan'.
 
- [STATISTICS]
- - code churn: 9 files changed, 41 insertions(+), 25 deletions(-)
+  [ STATISTICS ]
+    - code churn: 9 files changed, 41 insertions(+), 25 deletions(-)
 
 1.0.0 2013-01-01
- [API CHANGES]
- - Major rewrite using MooseX::App
+  [ API CHANGES ]
+    - Major rewrite using MooseX::App
 
- [ENHANCEMENTS]
- - cpan-git-import now uses metacpan instead of CPANPLUS
- - removed gitpan support, as it has gone dormant
+  [ ENHANCEMENTS ]
+    - cpan-git-import now uses metacpan instead of CPANPLUS
+    - removed gitpan support, as it has gone dormant
 
- [STATISTICS]
- - code churn: 38 files changed, 1594 insertions(+), 1244 deletions(-)
+  [ STATISTICS ]
+    - code churn: 38 files changed, 1594 insertions(+), 1244 deletions(-)
 
 0.8.0 2012-05-22
- - code churn: 1 files changed, 4 insertions(+), 86 deletions(-)
+  - code churn: 1 files changed, 4 insertions(+), 86 deletions(-)
 
- [ENHANCEMENTS]
- - Added new command 'cpan-clone', which operates like git-clone [Mike
-   Doherty]
+  [ ENHANCEMENTS ]
+    - Added new command 'cpan-clone', which operates like git-clone [Mike
+      Doherty]
 
 0.7.0 2011-11-12
- [ENHANCEMENTS]
- - 'git cpan-init' now accepts a '--vcs' argument
- - new command 'git cpan-sources'
+  [ ENHANCEMENTS ]
+    - 'git cpan-init' now accepts a '--vcs' argument
+    - new command 'git cpan-sources'
 
 0.6.1 2011-06-05
- [BUG FIXES]
- - pass '--no-chain-reply-to' explicitly to 'git-send-email'.
- - git-cpan-sendpatch and git-cpan-sendemail now accept '--compose'.
-   (thanks to Olaf Alders for the bug report)
+  [ BUG FIXES ]
+    - pass '--no-chain-reply-to' explicitly to 'git-send-email'.
+    - git-cpan-sendpatch and git-cpan-sendemail now accept '--compose'.
+      (thanks to Olaf Alders for the bug report)
 
 0.6.0 2011-03-06
- - don't blindly import perl if the module is core, but rather suggest to
-   use the Perl git repository instead. Thanks to Rafael Kitover for the
-   bug report (RT#66416)
+  - don't blindly import perl if the module is core, but rather suggest to
+    use the Perl git repository instead. Thanks to Rafael Kitover for the
+    bug report (RT#66416)
 
 0.5.0 2011-03-05
- - use Git::Repository instead of Git for the git interactions. Thanks to
-   brian d foy and Philippe Bruhat for the patches.
+  - use Git::Repository instead of Git for the git interactions. Thanks to
+    brian d foy and Philippe Bruhat for the patches.
 
 0.4.6 2010-10-11
- - move 'File::chmod' before 'autodie' to hush the warnings. (RT#61034)
+  - move 'File::chmod' before 'autodie' to hush the warnings. (RT#61034)
 
 0.4.5 2010-08-16
- - fix --force documentation/error message/support for git-cpan-import.
-   Thanks to chocolateboy.
+  - fix --force documentation/error message/support for git-cpan-import.
+    Thanks to chocolateboy.
 
 0.4.4 2010-06-07
- - Small doc fix for git-backpan-init. Thanks to chocolateboy.
- - Fix "Can't use string as an ARRAY ref" error introduced in 0.3.2. 
-   Thanks to chocolateboy.
- - Fix repo initialization as per the documentation.  Thanks to
-   chocolateboy.
+  - Small doc fix for git-backpan-init. Thanks to chocolateboy.
+  - Fix "Can't use string as an ARRAY ref" error introduced in 0.3.2. 
+    Thanks to chocolateboy.
+  - Fix repo initialization as per the documentation.  Thanks to
+    chocolateboy.
 
 0.4.3 2010-06-06
- - Still have troubles with the version number and the indexer.
+  - Still have troubles with the version number and the indexer.
 
 0.4.2 2010-06-06
- - Return to the format vx.y.z to keep the CPAN indexer happy. Bleh.
+  - Return to the format vx.y.z to keep the CPAN indexer happy. Bleh.
 
 0.4.1 2010-06-06
- - Fix the META.yml so that the version is correct.
+  - Fix the META.yml so that the version is correct.
 
 0.4.0 2010-06-05
- - Fix git-cpan-which so that it doesn't return a leading space. Thanks to
-   Tim Bunce. (rt-58001)
- - Check at install time if Git.pm (and thus Git) is present.
- - Add a --gitpan option for git-cpan0-import
+  - Fix git-cpan-which so that it doesn't return a leading space. Thanks to
+    Tim Bunce. (rt-58001)
+  - Check at install time if Git.pm (and thus Git) is present.
+  - Add a --gitpan option for git-cpan0-import
 
 0.3.2 2010-04-25
- - Explicitly requires perl 5.10. (rt-54368, reported by Jesse Vincent)
- - Preventive dying if we don't see the body_* functions. (rt-46715,
-   reported by Alexandr Ciornii)
- - Moved Module::Build to 'configure_requires'. (rt-44925, reported by
-   Jesse Vincent)
- - create_makefile_pl now set to small
+  - Explicitly requires perl 5.10. (rt-54368, reported by Jesse Vincent)
+  - Preventive dying if we don't see the body_* functions. (rt-46715,
+    reported by Alexandr Ciornii)
+  - Moved Module::Build to 'configure_requires'. (rt-44925, reported by
+    Jesse Vincent)
+  - create_makefile_pl now set to small
 
 0.3.1 2009-12-20
- - Getting git cpan-import --backpan to work again
- - Adding dependencies for Parse::BACKPAN::Packages, File::Temp, CLASS and
-   File::chmod
- - Adding a 'use 5.010'
+  - Getting git cpan-import --backpan to work again
+  - Adding dependencies for Parse::BACKPAN::Packages, File::Temp, CLASS and
+    File::chmod
+  - Adding a 'use 5.010'
 
 0.3.0 2009-12-20
- - Temporary directory are removed after used. Thanks to Slaven Rezic.
- - git-backpan-init, --mkdir make full directory paths. Thanks to Schwern.
- - git-backpan-init, add a --backpan option to supply your  own backpan
-   URL. Thanks to Schwern.
- - Guts of git-cpan-import moved to Git::CPAN::Patch::Import. Thanks to
-   Schwern.
- - git-cpan-* just install themselves as regular scripts instead of hunting
-   the git directory, as git will pull commands from anyway in the PATH.
-   Thanks to Schwern.
- - Distributions no longer lower cased. Thanks to Schwern.
- - Date bug fixed. Thanks to Schwern.
- - Adding File::Path to the dependencies.
- - Include the CPAN id of the author in the commit log. Thanks to Schwern.
- - PPM files are now skipped. Thanks to Schwern.
- - Skip perl distributions. Thanks to Schwern.
- - Have Archive::Extract prefer binary programs for performance. Thanks to
-   Schwern.
- - Overwrite existing version tags if there's two releases with  the same
-   versions. Thanks to Schwern.
- - Some archives have broken permissions.  Fix them after extraction.
-   Thanks to Schwern.
- - Record the file we imported from in the commit message. Thanks to
-   Schwern.
- - Use File::chmod instead of shell chmod to avoid shell quoting problems.
-   Thanks to Schwern.
- - Don't try to tag releases with no versions.				   
-      Thanks to Schwern.
- - Tag .1 as 0.1.  git doesn't like a tag named .1 Thanks to Schwern.
- - Skip empty tarballs.  Thanks to Schwern.
- - Skip bad archives.  Thanks to Schwern.
+  - Temporary directory are removed after used. Thanks to Slaven Rezic.
+  - git-backpan-init, --mkdir make full directory paths. Thanks to Schwern.
+  - git-backpan-init, add a --backpan option to supply your  own backpan
+    URL. Thanks to Schwern.
+  - Guts of git-cpan-import moved to Git::CPAN::Patch::Import. Thanks to
+    Schwern.
+  - git-cpan-* just install themselves as regular scripts instead of
+    hunting the git directory, as git will pull commands from anyway in the
+    PATH. Thanks to Schwern.
+  - Distributions no longer lower cased. Thanks to Schwern.
+  - Date bug fixed. Thanks to Schwern.
+  - Adding File::Path to the dependencies.
+  - Include the CPAN id of the author in the commit log. Thanks to Schwern.
+  - PPM files are now skipped. Thanks to Schwern.
+  - Skip perl distributions. Thanks to Schwern.
+  - Have Archive::Extract prefer binary programs for performance. Thanks to
+    Schwern.
+  - Overwrite existing version tags if there's two releases with  the same
+    versions. Thanks to Schwern.
+  - Some archives have broken permissions.  Fix them after extraction.
+    Thanks to Schwern.
+  - Record the file we imported from in the commit message. Thanks to
+    Schwern.
+  - Use File::chmod instead of shell chmod to avoid shell quoting problems.
+    Thanks to Schwern.
+  - Don't try to tag releases with no versions. 		       
+    Thanks to Schwern.
+  - Tag .1 as 0.1.  git doesn't like a tag named .1 Thanks to Schwern.
+  - Skip empty tarballs.  Thanks to Schwern.
+  - Skip bad archives.	    Thanks to Schwern.
 
 0.2.1 Thur Sept 3 2009
- - git-cpan-import is working with new version of Git.			   
-      Thanks to Alexandr Ciornii. (rt#48713)
- - Require CPANPLUS 0.84 or higher. Thanks to Alexandr Ciornii. (rt#48713)
+  - git-cpan-import is working with new version of Git. 	       
+    Thanks to Alexandr Ciornii. (rt#48713)
+  - Require CPANPLUS 0.84 or higher. Thanks to Alexandr Ciornii. (rt#48713)
 
 0.2.0 2009-07-11
- - New --parent option for git-cpan-import
+  - New --parent option for git-cpan-import
 
 0.1.7 2009-05-31
- - git-backpan-init doesn't choke on bad versions but skip them (rt bug
-   46469)
+  - git-backpan-init doesn't choke on bad versions but skip them (rt bug
+    46469)
 
 0.1.6 2009-05-12
- - git-backpan-init doesn't choke on non-monotone version numbers anymore
-   (rt bug 45994)
- - git-cpan-import gets a new --checkversion option
- - Adding Module::Build as an explicit dependency and passthrough
-   Makefile.PL
+  - git-backpan-init doesn't choke on non-monotone version numbers anymore
+    (rt bug 45994)
+  - git-cpan-import gets a new --checkversion option
+  - Adding Module::Build as an explicit dependency and passthrough
+    Makefile.PL
 
 0.1.5 2009-03-28
- - Fixed typo in git-cpan-squash doc (rt bug 43294),  patch by Slaven Rezic
- - Removed warning from git-cpan-import,  patch by Pedro Melo
- - scripts' shebang line now set to Perl's interpreter			   
-      used by Build.PL (rt bug 43366)
+  - Fixed typo in git-cpan-squash doc (rt bug 43294),  patch by Slaven
+    Rezic
+  - Removed warning from git-cpan-import,  patch by Pedro Melo
+  - scripts' shebang line now set to Perl's interpreter 	       
+    used by Build.PL (rt bug 43366)
 
 0.1.4 2009-02-14
- - backpan-init now calls cpan-import properly (fix by Slaven Rezic)
- - CPANPlUS added as dependency
- - Documentation correction (patch by 2shortplanks)
+  - backpan-init now calls cpan-import properly (fix by Slaven Rezic)
+  - CPANPlUS added as dependency
+  - Documentation correction (patch by 2shortplanks)
 
 0.1.3 2009-02-05
- - Of course, removing 5.10 requirements in Build.PL would help... *sigh*
+  - Of course, removing 5.10 requirements in Build.PL would help... *sigh*
 
 0.1.2 2009-02-03
- - Made scripts Perl 5.8-compatible
+  - Made scripts Perl 5.8-compatible
 
 0.1.1 2009-02-03
- - Removed dependency on List::MoreUtils from Build.PL
+  - Removed dependency on List::MoreUtils from Build.PL
 
 0.1.0 2009-02-02
- - First CPAN release.
- - Massive restructuration and explosion of features, thanks to  Yuval
-   Kogman.
+  - First CPAN release.
+  - Massive restructuration and explosion of features, thanks to  Yuval
+    Kogman.
 
 0.0.1 December 2008
- - Original scripts are published alongside the article "CPAN Patching with
-   Git" in issue 5.1 of the Perl Review.
-
+  - Original scripts are published alongside the article "CPAN Patching
+    with Git" in issue 5.1 of the Perl Review.

--- a/Changes
+++ b/Changes
@@ -10,6 +10,7 @@ Revision history for Git::CPAN::Patch
   [ ENHANCEMENTS ]
 
   [ NEW FEATURES ]
+    - Store module name in config instead of relying on commit messages
 
   [ STATISTICS ]
 

--- a/lib/Git/CPAN/Patch/Command/Import.pm
+++ b/lib/Git/CPAN/Patch/Command/Import.pm
@@ -95,6 +95,7 @@ method get_releases_from_local_file($path) {
 method clone_git_repo($release,$url) {
     $self->git_run( 'remote', 'add', 'cpan', $url );
     $self->git_run( 'fetch', 'cpan' );
+    $self->git_run( config => 'cpan.module-name', $release->dist_name );
 }
 
 sub looks_like_git {
@@ -239,6 +240,7 @@ END
         say "created tag '@{[ 'v'.$release->dist_version ]}' ($commit)";
     }
 
+    $self->git_run( config => 'cpan.module-name', $release->dist_name );
 }
 
 method run {

--- a/lib/Git/CPAN/Patch/Role/Patch.pm
+++ b/lib/Git/CPAN/Patch/Role/Patch.pm
@@ -34,12 +34,19 @@ has module_name => (
     isa => 'Str',
     lazy => 1,
     default => method {
+
+        if (my $module = $self->git->run('config', 'cpan.module-name')) {
+            return $module
+        }
+
         my $last_commit = $self->git->run('rev-parse', '--verify', 'cpan/master');
 
         my $last = join "\n", $self->git->run( log => '--pretty=format:%b', '-n', 1, $last_commit );
 
         $last =~ /git-cpan-module: \s+ (.*?) \s+ git-cpan-version: \s+ (.*?) \s*$/sx
             or die "Couldn't parse message:\n$last\n";
+
+        $self->git->run('config', 'cpan.module-name', $1);
 
         return $1;
     },


### PR DESCRIPTION
This should help resolve #24.  Basically instead of relying on meticulously
formatted commit messages we instead set the module name at clone time.

