### PR TITLE
Option --check should have negated option

### DIFF
--- a/lib/Git/CPAN/Patch/Command/Import.pm
+++ b/lib/Git/CPAN/Patch/Command/Import.pm
@@ -51,6 +51,7 @@ option check => (
     is => 'ro',
     isa => 'Bool',
     default => 1,
+    cmd_negate => 'nocheck',
     documentation => q{Verifies that the imported version is greater than what is already imported},
 );
 


### PR DESCRIPTION
This fixes the option to match the documentation.

```
-(import-nocheck)-♥ perl -Ilib ./bin/git-cpan clone PDL::CCS PDL-CCS-check
creating PDL-CCS-check
created tag 'v1.14' (87ce994f8e33736b517d8aff65ef7aefb21583ed)
created tag 'v1.15' (6bd432639e5de5f101c1922257eeca23ddf5ad78)
created tag 'v1.16' (be10b1adb692b19be05c8e81f7696b06235eca6a)
created tag 'v1.17' (b4990e02eb18b7bfc034611bae68d82905094478)
last imported version 1.17 is more recent than 1.18.1, can't import
last imported version 1.17 is more recent than 1.19.0, can't import
last imported version 1.17 is more recent than 1.19.1, can't import
last imported version 1.17 is more recent than 1.20.1, can't import
last imported version 1.17 is more recent than 1.20.2, can't import
last imported version 1.17 is more recent than 1.21.0, can't import
last imported version 1.17 is more recent than 1.22.0, can't import
last imported version 1.17 is more recent than 1.22.1, can't import
last imported version 1.17 is more recent than v1.22.2, can't import
last imported version 1.17 is more recent than v1.22.4, can't import
last imported version 1.17 is more recent than v1.22.5, can't import
last imported version 1.17 is more recent than v1.22.6, can't import
last imported version 1.17 is more recent than v1.23.0, can't import
last imported version 1.17 is more recent than v1.23.1, can't import
last imported version 1.17 is more recent than v1.23.2, can't import
last imported version 1.17 is more recent than v1.23.3, can't import
last imported version 1.17 is more recent than v1.23.4, can't import
last imported version 1.17 is more recent than v1.23.5, can't import
last imported version 1.17 is more recent than v1.23.6, can't import
last imported version 1.17 is more recent than v1.23.7, can't import
last imported version 1.17 is more recent than v1.23.8, can't import
last imported version 1.17 is more recent than v1.23.9, can't import
last imported version 1.17 is more recent than v1.23.10, can't import
last imported version 1.17 is more recent than v1.23.11, can't import
last imported version 1.17 is more recent than v1.23.12, can't import
last imported version 1.17 is more recent than v1.23.13, can't import
```

```
-(import-nocheck)-♥ perl -Ilib ./bin/git-cpan clone --nocheck PDL::CCS PDL-CCS-nocheck
creating PDL-CCS-nocheck
created tag 'v1.14' (edc5ff70a47e7f8f240c4afe581ebcc66af21b55)
created tag 'v1.15' (a6eae82eba831dc60778e52a867e73f463a3f8f8)
created tag 'v1.16' (a313facb01467c676ec8b7af5753be72d1fdba07)
created tag 'v1.17' (9c6fddc2a7508c10218166c973c5a423abbcfb0f)
created tag 'v1.18.1' (ba79602b99694b76f9c8f4594026401621d9a5f1)
created tag 'v1.19.0' (946e079ad8739b091ba8863bb0b99eca7be675d4)
created tag 'v1.19.1' (ccfdc54d4d576551958106a2b5cbfa43f614d4dd)
created tag 'v1.20.1' (3413c875d8252d48f45d7e36e0ff25e81fa79aa1)
created tag 'v1.20.2' (5411ca8b9af7bd71b0b92a87dac7aff853b82053)
created tag 'v1.21.0' (a165ffb339f9a22517775a43b4f99e1f934ab1d4)
created tag 'v1.22.0' (8d8bd6426df00ccbccb243637e1b1ad427a927d9)
created tag 'v1.22.1' (05367e27d46bfbc2e932ff59cdc75e00eeda431a)
created tag 'vv1.22.2' (f1d76a418a3a5547f1469d22721ceda1c6735edd)
created tag 'vv1.22.4' (9bf725061ea8c7829b9a2d1f07291c212f69db43)
created tag 'vv1.22.5' (ed5886a7d4721a5641e547f9b0f43216dac8f241)
created tag 'vv1.22.6' (a1be0f252bb989b6c44867d9e60c5f05a7e06920)
created tag 'vv1.23.0' (9ce2ac076c8169409ee39666c27f83cba58fa612)
created tag 'vv1.23.1' (18b8984cce6f0b364ee8578b0b7a375e0e1bd512)
created tag 'vv1.23.2' (f5e78e0ff47ff42bb9d09999834c3b8911f909cc)
created tag 'vv1.23.3' (6410ca3ebb038e84859557936b82e732d87704fa)
created tag 'vv1.23.4' (eb78e3003790ffd13500d4ab480082f1c80530d4)
created tag 'vv1.23.5' (c7d665476cfdbd302c1dd16568a874be457cebfd)
created tag 'vv1.23.6' (1a56ea02163e87187d4b5085bb5deba5145466f0)
created tag 'vv1.23.7' (b10c926c375b2b17288c54b1278266d3302570ef)
created tag 'vv1.23.8' (f373f72c9d8e374966b169426be0ad9da313a2d2)
created tag 'vv1.23.9' (db750f35b330d08190c8e111fdbcd56cf732cdaf)
created tag 'vv1.23.10' (7222f2a2c56d0f593a1e12f8bb9ba78cc253fe9b)
created tag 'vv1.23.11' (b9637abe7e97cd655f97d79a7ed8ad0b9c30a873)
created tag 'vv1.23.12' (4f08788ab4f6691fce42606712a159f835eef27c)
created tag 'vv1.23.13' (c6469b21aa77fdbd325238d04d8d57a6edf80c69)
```
