### PR TITLE
Only prefix tag with 'v' if needed

### DIFF
--- a/lib/Git/CPAN/Patch/Command/Import.pm
+++ b/lib/Git/CPAN/Patch/Command/Import.pm
@@ -254,9 +254,10 @@ END
 
         print $self->git_run('update-ref', '-m' => "import " . $release->dist_name, 'refs/remotes/cpan/master', $commit );
 
-        print $self->git_run( tag => 'v'.$release->dist_version, $commit );
+        my $tag_name = $release->dist_version =~ /^v/ ? $release->dist_version : 'v'.$release->dist_version;
+        print $self->git_run( tag => $tag_name, $commit );
 
-        say "created tag '@{[ 'v'.$release->dist_version ]}' ($commit)";
+        say "created tag '@{[ $tag_name ]}' ($commit)";
     }
 
     $self->git_run( config => 'cpan.module-name', $release->dist_name );


### PR DESCRIPTION
This prevents having tags such as "vvX.Y.Z".

```
-(master=)-☠ R="perl -Ilib ./bin/git-cpan clone --norepository MooX::Should"; for b in master tag-no-double-v; do git checkout $b; eval "$R MooX-Should-$b"; done
Already on 'master'
Your branch is up to date with 'origin/master'.
creating MooX-Should-master
created tag 'vv0.1.0' (e72c33ba1d2b7b93de9ea00b5e04172433a365c9)
created tag 'vv0.1.1' (e531b9240acf35202b8e8e7eac8dc5018e4ff6b9)
created tag 'vv0.1.2' (4497cd230940ba78009b5114bef79531cae05236)
created tag 'vv0.1.3' (4340da19d848d891e3161e9232e138c95a96dc5a)
created tag 'vv0.1.4' (ea321ccf8ed619b0311a4caa43b17e0c33a9b49f)
Switched to branch 'tag-no-double-v'
Your branch is up to date with 'origin/tag-no-double-v'.
creating MooX-Should-tag-no-double-v
created tag 'v0.1.0' (d54d2f7925105a0209a7ed24031e0e97fb0032c8)
created tag 'v0.1.1' (6b98d366c17fe655b1b66ed66b9330ef6ad69d65)
created tag 'v0.1.2' (fc824eeb05f87276bc01a88e637e09f90ebb1c36)
created tag 'v0.1.3' (25b2e3b5c6343590dda51a9e6d820f520c94283b)
created tag 'v0.1.4' (d54ef78453eb69ccef4eac65701686b2e0194886)
```
