### PR TITLE
drop dependency on CLASS module

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,7 @@ Revision history for Git::CPAN::Patch
  [DOCUMENTATION]
 
  [ENHANCEMENTS]
+ - Remove dependency on CLASS module
 
  [NEW FEATURES]
 

--- a/cpanfile
+++ b/cpanfile
@@ -4,7 +4,6 @@
 requires "Archive::Any" => "0";
 requires "Archive::Extract" => "0";
 requires "BackPAN::Index" => "0";
-requires "CLASS" => "0";
 requires "CPAN::Meta" => "0";
 requires "CPAN::ParseDistribution" => "0";
 requires "CPANPLUS" => "0";

--- a/lib/Git/CPAN/Patch/Import.pm
+++ b/lib/Git/CPAN/Patch/Import.pm
@@ -26,7 +26,6 @@ use Path::Class qw/ file /;
 use Cwd qw/ getcwd /;
 use version;
 use Git::Repository;
-use CLASS;
 use DateTime;
 
 use CPANPLUS;
@@ -200,7 +199,7 @@ sub import_one_backpan_release {
     local %ENV = %ENV;
     $ENV{GIT_AUTHOR_DATE}  ||= $release->date;
 
-    my $author = $CLASS->cpanplus->author_tree($release->cpanid);
+    my $author = __PACKAGE__->cpanplus->author_tree($release->cpanid);
     $ENV{GIT_AUTHOR_NAME}  ||= $author->author;
     $ENV{GIT_AUTHOR_EMAIL} ||= $author->email;
 
@@ -263,7 +262,7 @@ sub import_from_backpan {
 
     local $CWD = $repo_dir;
 
-    my $backpan = $CLASS->backpan_index;
+    my $backpan = __PACKAGE__->backpan_index;
     my $dist = $backpan->dist($distname)
       or die "Error: no distributions found. ",
              "Are you sure you spelled the module name correctly?\n";
@@ -468,7 +467,7 @@ sub main {
 
                 if ( $opts->{backpan} ) {
                     # we need the backpan index for dates
-                    my $backpan = $CLASS->backpan_index;
+                    my $backpan = __PACKAGE__->backpan_index;
 
                     %dists = map { $_->filename => $_ }
                     $backpan->releases($release->{name});


### PR DESCRIPTION
The CLASS module adds a trivial convenience of being able to use $CLASS
rather than __PACKAGE__. The CLASS module has an uncertain future,
because it currently has a maintainer attempting to combine it with a
massive complex object system, reusing the name for something entirely
unrelated. Since it is trivial to do without, just remove the
prerequisite.