### PR TITLE
Never sign git tags

### DIFF
--- a/lib/Git/CPAN/Patch/Command/Import.pm
+++ b/lib/Git/CPAN/Patch/Command/Import.pm
@@ -257,7 +257,7 @@ END
         print $self->git_run('update-ref', '-m' => "import " . $release->dist_name, 'refs/remotes/cpan/master', $commit );
 
         my $tag_name = $release->dist_version =~ /^v/ ? $release->dist_version : 'v'.$release->dist_version;
-        print $self->git_run( tag => $tag_name, $commit );
+        print $self->git_run( tag => $tag_name, '--no-sign', $commit );
 
         say "created tag '@{[ $tag_name ]}' ($commit)";
     }

--- a/lib/Git/CPAN/Patch/Import.pm
+++ b/lib/Git/CPAN/Patch/Import.pm
@@ -234,7 +234,7 @@ END
         if( $repo->run( "tag", "-l" => $tag ) ) {
             say "Tag $tag already exists, overwriting";
         }
-        print $repo->run( "tag", "-f" => $tag, $commit );
+        print $repo->run( "tag", "-f" => $tag, '--no-sign', $commit );
         say "created tag '$tag' ($commit)";
     }
 }
@@ -516,7 +516,7 @@ END
 
         print $repo->run('update-ref', '-m' => "import $dist", 'refs/remotes/cpan/master', $commit );
 
-        print $repo->run( tag => $version, $commit );
+        print $repo->run( tag => $version, '--no-sign', $commit );
 
         say "created tag '$version' ($commit)";
     }


### PR DESCRIPTION
I ran into `git cpan-clone Some::Module` just hanging during import of the initial release.

But of debugging and its because my global `$HOME/.gitconfig` is set up to GPG sign tags:

```
[tag]
	gpgSign = true
```

So when it imports the release it tags the release and its just sitting there trying to run `$EDITOR` waiting for me to edit the commit message.

Workaround is to pass `--no-sign` to all `git tag` commands.